### PR TITLE
fix: unify chart counter position for all charts

### DIFF
--- a/frontend/src/app/components/SurveyBlock/AnswerContainer.tsx
+++ b/frontend/src/app/components/SurveyBlock/AnswerContainer.tsx
@@ -9,25 +9,29 @@ const AnswerContainer = ({ tabs, children }: Props) => {
 
   return (
     <div className={`bg-[#3b3f45] rounded-2xl flex-[5] shadow-md`}>
-      {!!tabs?.length && (
-        <div className="flex bg-[#2f3237] p-4 rounded-2xl rounded-b-none gap-8 justify-center">
-          {tabs.map((tab, index) => (
-            <button
-              key={index}
-              className={`flex-1 text-center font-bold text-sm rounded-md max-w-40 h-8
-                        ${
-                          activeTab === index
-                            ? "text-black bg-slate-50"
-                            : "text-white hover:text-blue-400 "
-                        }`}
-              onClick={() => setActiveTab(index)}
-            >
-              {tab}
-            </button>
-          ))}
+      <div className="relative flex flex-col h-full">
+        {!!tabs?.length && (
+          <div className="flex bg-[#2f3237] p-4 rounded-2xl rounded-b-none gap-8 justify-center">
+            {tabs.map((tab, index) => (
+              <button
+                key={index}
+                className={`flex-1 text-center font-bold text-sm rounded-md max-w-40 h-8
+                  ${
+                    activeTab === index
+                      ? "text-black bg-slate-50"
+                      : "text-white hover:text-blue-400"
+                  }`}
+                onClick={() => setActiveTab(index)}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+        )}
+        <div className="flex-1">
+          {Array.isArray(children) ? children[activeTab] : children}
         </div>
-      )}
-        {Array.isArray(children) ? children[activeTab] : children}
+      </div>
     </div>
   );
 };

--- a/frontend/src/app/components/charts/BarChart.tsx
+++ b/frontend/src/app/components/charts/BarChart.tsx
@@ -68,13 +68,17 @@ const BarChart = ({ x, y }: BarChartData) => {
 
   return (
     <div className="chart-container py-6">
-      <Plot
-        data={chartData}
-        layout={layout}
-        config={config}
-        style={{ width: "100%", height: plotHeight }}
-      />
-      <ChartCounter number={50} total={200} />
+      <div className="flex-1">
+        <Plot
+          data={chartData}
+          layout={layout}
+          config={config}
+          style={{ width: "100%", height: plotHeight }}
+        />
+      </div>
+      <div className="mt-auto ml-auto">
+        <ChartCounter number={50} total={200} />
+      </div>
     </div>
   );
 };

--- a/frontend/src/app/components/charts/ChartCounter.tsx
+++ b/frontend/src/app/components/charts/ChartCounter.tsx
@@ -9,7 +9,7 @@ const ChartCounter = ({ number, total }: ChartCounterProps) => {
   const percentage = total > 0 ? ((number / total) * 100).toFixed(0) : "0";
 
   return (
-    <div className=" absolute right-8 bottom-20 flex flex-row items-center space-x-1 text-white">
+    <div className="flex items-center space-x-1 text-white">
       <div>Antall svar:</div>
       <div className="font-bold">{number.toString()}</div>
       <div className="font-bold">({percentage}%)</div>

--- a/frontend/src/app/components/charts/DotPlotChart.tsx
+++ b/frontend/src/app/components/charts/DotPlotChart.tsx
@@ -82,7 +82,7 @@ const DotPlotChart = ({ title, data }: DotPlotChartJsonProps) => {
   };
 
   return (
-    <div className="chart-container dotplot">
+    <div className="chart-container dotplot pb-4">
       <Plot // @ts-expect-error Disable type check for Plot
         data={traces}
         layout={layout}
@@ -90,7 +90,9 @@ const DotPlotChart = ({ title, data }: DotPlotChartJsonProps) => {
         useResizeHandler={true}
         style={{ width: "100%", height: plotHeight }}
       />
-      <ChartCounter number={50} total={200} />
+      <div className="mt-auto mb-2 ml-auto">
+        <ChartCounter number={50} total={200} />
+      </div>
     </div>
   );
 };

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -55,7 +55,7 @@ body {
   }
 
   .chart-container {
-    @apply w-full relative h-full px-8;
+    @apply w-full h-full relative px-8 flex flex-col justify-between;
   }
 }
 


### PR DESCRIPTION
- Added flex-1 container around children in answerContiner
- Removed absolute positioning on chart counter in favor of margin top auto to ensure
- Added flex and updated chart-container style to allow a uniform positioning for the chartcounter

# Description

<!-- Please include a summary of the changes. -->

## Testing Done

<!-- Describe the tests you have conducted to verify your changes. -->

## Type of change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Documentation update required for this change

## Checklist:

- [ ] My code adheres to the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added comments to my code, especially in complex areas
- [ ] I have updated the documentation accordingly
- [ ] My changes do not introduce any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my feature
- [ ] Both new and existing unit tests pass locally with my changes
- [ ] I have considered and addressed any potential security implications
